### PR TITLE
Override default severity colors in config.js

### DIFF
--- a/app/config.js.example
+++ b/app/config.js.example
@@ -1,0 +1,25 @@
+'use strict';
+
+angular.module('config', [])
+  .constant('config', {
+    'endpoint'    : "http://"+window.location.hostname+":8080",
+    'provider'    : "basic", // google, github, twitter or basic
+    'client_id'   : "INSERT-CLIENT-ID-HERE"
+  })
+  .constant('colors', {
+    'severity': {
+      'critical'     : '#D8122A',
+      'major'        : '#EA680F',
+      'minor'        : '#FFBE1E',
+      'warning'      : '#BA2222',
+      'indeterminate': '#A6ACA8',
+      'cleared'      : '#00AA5A',
+      'normal'       : '#00AA5A',
+      'ok'           : '#00AA5A',
+      'informational': '#00A1BC',
+      'debug'        : '#9D006D',
+      'security'     : '#333333',
+      'unknown'      : '#A6ACA8'
+    },
+    'text': 'white'
+  });

--- a/app/css/app.css
+++ b/app/css/app.css
@@ -39,37 +39,6 @@ table {
     border: 1px solid #000;
 }
 
-.severity {
-    background-color: silver;
-}
-
-.severity-critical {
-    background-color: red;
-}
-
-.severity-major {
-    background-color: orange;
-}
-
-.severity-minor {
-    background-color: yellow;
-}
-
-.severity-warning {
-    background-color: #1E90FF; // dodger-blue
-}
-
-.severity-normal,
-.severity-cleared,
-.severity-ok,
-.severity-informational {
-    background-color: #00CC00;
-}
-
-.severity-debug {
-    background-color: #7554BF;
-}
-
 .label {
     font-size: 10.998px;
     font-weight: bold;

--- a/app/index.html
+++ b/app/index.html
@@ -63,10 +63,10 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
   <script src="//netdna.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
 
-  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.14/angular.min.js"></script>
-  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.14/angular-route.min.js"></script>
-  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.14/angular-resource.min.js"></script>
-  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.14/angular-sanitize.min.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.3/angular.min.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.3/angular-route.min.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.3/angular-resource.min.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.3/angular-sanitize.min.js"></script>
 
   <script src="config.js"></script>
 

--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -39,8 +39,28 @@ alertaControllers.controller('MenuController', ['$scope', '$location', '$auth', 
 
   }]);
 
-alertaControllers.controller('AlertListController', ['$scope', '$location', '$timeout', 'Count', 'Environment', 'Service', 'Alert',
-  function($scope, $location, $timeout, Count, Environment, Service, Alert){
+alertaControllers.controller('AlertListController', ['$scope', '$location', '$timeout', 'colors', 'Count', 'Environment', 'Service', 'Alert',
+  function($scope, $location, $timeout, colors, Count, Environment, Service, Alert){
+
+    var defaults = {
+      severity: {
+        critical: 'red',
+        major: 'orange',
+        minor: 'yellow',
+        warning: '#1E90FF',
+        indeterminate: 'silver',
+        cleared: '#00CC00',
+        normal: '#00CC00',
+        ok: '#00CC00',
+        informational: '#00CC00',
+        debug: '#7554BF',
+        security: 'black',
+        unknown: 'silver'
+      },
+      text: 'black'
+    };
+
+    $scope.colors = angular.merge(defaults, colors);
 
     $scope.autoRefresh = true;
     $scope.refreshText = 'Auto Update';
@@ -158,9 +178,10 @@ alertaControllers.controller('AlertListController', ['$scope', '$location', '$ti
         'indeterminate': 5,
         'cleared': 5,
         'normal': 5,
+        'ok': 5,
         'informational': 6,
         'debug': 7,
-        'auth': 8,
+        'security': 8,
         'unknown': 9
     };
 

--- a/app/partials/alert-list.html
+++ b/app/partials/alert-list.html
@@ -49,7 +49,7 @@
         </tr>
 
         <tr ng-repeat="alert in alerts | filter:search | orderBy:predicate:reverse | limitTo:alertLimit"
-            class="severity severity-{{ alert.severity}}"
+            ng-style="{ 'color':  colors.severity[alert.severity] == 'black' ? 'white' : colors.text, 'background-color': colors.severity[alert.severity] }"
             ng-controller="AlertLinkController" ng-click="getDetails(alert);">
           <td class="hidden-xs no-wrap"><i class="glyphicon glyphicon-{{ alert.trendIndication | arrow }}"></i>&nbsp;<span class="label label-{{ alert.severity }}">{{ alert.severity | capitalize }}</span></td>
           <td class="hidden-xs"><span class="label label-{{ alert.status }}">{{ alert.status | capitalize }}</span></td>


### PR DESCRIPTION
Example config: 

```
  .constant('colors', {
    'severity': {
      'critical'     : '#D8122A',
      'major'        : '#EA680F',
      'minor'        : '#FFBE1E',
      'warning'      : '#BA2222',
      'indeterminate': '#A6ACA8',
      'cleared'      : '#00AA5A',
      'normal'       : '#00AA5A',
      'ok'           : '#00AA5A',
      'informational': '#00A1BC',
      'debug'        : '#9D006D',
      'security'     : '#333333',
      'unknown'      : '#A6ACA8'
    },
    'text': 'white'
  });
```

Fixes #21 