### PR TITLE
bulk actions on multiple alerts

### DIFF
--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -39,8 +39,8 @@ alertaControllers.controller('MenuController', ['$scope', '$location', '$auth', 
 
   }]);
 
-alertaControllers.controller('AlertListController', ['$scope', '$location', '$timeout', 'colors', 'Count', 'Environment', 'Service', 'Alert',
-  function($scope, $location, $timeout, colors, Count, Environment, Service, Alert){
+alertaControllers.controller('AlertListController', ['$scope', '$route', '$location', '$timeout', 'colors', 'Count', 'Environment', 'Service', 'Alert',
+  function($scope, $route, $location, $timeout, colors, Count, Environment, Service, Alert){
 
     var defaults = {
       severity: {
@@ -193,6 +193,75 @@ alertaControllers.controller('AlertListController', ['$scope', '$location', '$ti
       return SEVERITY_MAP[alert.severity];
     };
 
+    $scope.bulkAlerts = [];
+
+    $scope.getDetails = function($event,alert) {
+      if ($event.metaKey) {
+        $scope.bulkAlerts.push(alert.id);
+      } else {
+        $location.url('/alert/' + alert.id);
+      }
+    };
+
+    $scope.bulkOpenAlert = function(ids) {
+      angular.forEach(ids, function(id) {
+        Alert.status({id: id}, {status: 'open', text: 'bulk status change via console'}, function(data) {
+          // $route.reload();
+        });
+      });
+      $route.reload();
+    };
+
+    // $scope.bulkTagAlert = function(id, tags) {
+    //   Alert.tag({id: id}, {tags: tags}, function(data) {
+    //     $route.reload();
+    //   });
+    // };
+
+    $scope.bulkWatchAlert = function(ids, user) {
+      angular.forEach(ids, function(id) {
+        Alert.tag({id: id}, {tags: ['watch:' + user]}, function(data) {
+          // $route.reload();
+        });
+      });
+      $route.reload();
+    };
+
+    $scope.bulkUnwatchAlert = function(ids, user) {
+      angular.forEach(ids, function(id) {
+        Alert.untag({id: id}, {tags: ['watch:' + user]}, function(data) {
+          // $route.reload();
+        });
+      });
+      $route.reload();
+    };
+
+    $scope.bulkAckAlert = function(ids) {
+      angular.forEach(ids, function(id) {
+        Alert.status({id: id}, {status: 'ack', text: 'bulk status change via console'}, function(data) {
+          // $route.reload();
+        });
+      });
+      $route.reload();
+    };
+
+    $scope.bulkCloseAlert = function(ids) {
+      angular.forEach(ids, function(id) {
+        Alert.status({id: id}, {status: 'closed', text: 'bulk status change via console'}, function(data) {
+          // $route.reload();
+        });
+      });
+      $route.reload();
+    };
+
+    $scope.bulkDeleteAlert = function(ids) {
+      angular.forEach(ids, function(id) {
+        Alert.delete({id: id}, {}, function(data) {
+          // $location.path('/');
+        });
+      });
+      $route.reload();
+    };
   }]);
 
 alertaControllers.controller('AlertDetailController', ['$scope', '$route', '$routeParams', '$location', '$auth', 'Alert',
@@ -218,11 +287,11 @@ alertaControllers.controller('AlertDetailController', ['$scope', '$route', '$rou
       });
     };
 
-    $scope.tagAlert = function(id, tags) {
-      Alert.tag({id: id}, {tags: tags}, function(data) {
-        $route.reload();
-      });
-    };
+    // $scope.tagAlert = function(id, tags) {
+    //   Alert.tag({id: id}, {tags: tags}, function(data) {
+    //     $route.reload();
+    //   });
+    // };
 
     $scope.watchAlert = function(id, user) {
       Alert.tag({id: id}, {tags: ['watch:' + user]}, function(data) {
@@ -403,14 +472,15 @@ alertaControllers.controller('AlertWatchController', ['$scope', '$timeout', '$au
       }
     });
 
-  }]);
-
-alertaControllers.controller('AlertLinkController', ['$scope', '$location',
-  function($scope, $location) {
-
-    $scope.getDetails = function(alert) {
-      $location.url('/alert/' + alert.id);
+    $scope.getDetails = function($event,alert) {
+      console.log($event.metaKey);
+      if ($event.metaKey) {
+        $scope.bulkAlerts.push(alert.id);
+      } else {
+        $location.url('/alert/' + alert.id);
+      }
     };
+
   }]);
 
 alertaControllers.controller('AlertBlackoutController', ['$scope', '$route', '$timeout', '$auth', 'Blackouts', 'Environment', 'Service',

--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -39,8 +39,18 @@ alertaControllers.controller('MenuController', ['$scope', '$location', '$auth', 
 
   }]);
 
-alertaControllers.controller('AlertListController', ['$scope', '$route', '$location', '$timeout', 'colors', 'Count', 'Environment', 'Service', 'Alert',
-  function($scope, $route, $location, $timeout, colors, Count, Environment, Service, Alert){
+alertaControllers.controller('AlertListController', ['$scope', '$route', '$location', '$timeout', '$auth', 'colors', 'Count', 'Environment', 'Service', 'Alert',
+  function($scope, $route, $location, $timeout, $auth, colors, Count, Environment, Service, Alert){
+
+    if ($auth.isAuthenticated()) {
+      $scope.user = $auth.getPayload().name;
+     } else {
+       $scope.user = undefined;
+     };
+
+    $scope.isAuthenticated = function() {
+      return $auth.isAuthenticated();
+    };
 
     var defaults = {
       severity: {

--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -206,7 +206,7 @@ alertaControllers.controller('AlertListController', ['$scope', '$route', '$locat
     $scope.bulkAlerts = [];
 
     $scope.getDetails = function($event,alert) {
-      if ($event.metaKey) {
+      if ($event.metaKey || $event.altKey) {
         $scope.bulkAlerts.push(alert.id);
       } else {
         $location.url('/alert/' + alert.id);

--- a/app/partials/alert-list.html
+++ b/app/partials/alert-list.html
@@ -49,8 +49,8 @@
         </tr>
 
         <tr ng-repeat="alert in alerts | filter:search | orderBy:predicate:reverse | limitTo:alertLimit"
-            ng-style="{ 'color':  colors.severity[alert.severity] == 'black' ? 'white' : colors.text, 'background-color': colors.severity[alert.severity] }"
-            ng-controller="AlertLinkController" ng-click="getDetails(alert);">
+            ng-style="{ 'color':  colors.severity[alert.severity] == 'black' ? 'white' : colors.text, 'background-color': (bulkAlerts.indexOf(alert.id) > -1) ? '#E0D8E0' : colors.severity[alert.severity] }"
+            ng-click="getDetails($event,alert);">
           <td class="hidden-xs no-wrap"><i class="glyphicon glyphicon-{{ alert.trendIndication | arrow }}"></i>&nbsp;<span class="label label-{{ alert.severity }}">{{ alert.severity | capitalize }}</span></td>
           <td class="hidden-xs"><span class="label label-{{ alert.status }}">{{ alert.status | capitalize }}</span></td>
           <td class="hidden-lg">{{ alert.lastReceiveTime | date:'HH:mm' }}</td>
@@ -82,4 +82,29 @@
   </div>
   </div> <!-- row -->
 
+  <p>
+
+  <div class="row" ng-show="bulkAlerts.length > 0">
+    <div class="col-md-12">
+    <button type="button" class="btn btn-success"
+            ng-click="bulkOpenAlert(bulkAlerts)"
+            ng-disabled="status.indexOf('open') > -1"><i class="glyphicon glyphicon-arrow-up"></i> Open</button>
+    <!-- button type="button" class="btn btn-default"
+            ng-click="bulkTagAlert(alert.id, ['foo'])">Tag</button -->
+    <button type="button" class="btn btn-default"
+            ng-click="bulkWatchAlert(bulkAlerts, user)"
+            ng-disabled="!isAuthenticated();"><i class="glyphicon glyphicon-eye-open"></i> Watch</button>
+    <button type="button" class="btn btn-default"
+            ng-click="bulkUnwatchAlert(bulkAlerts, user)"
+            ng-disabled="!isAuthenticated();"><i class="glyphicon glyphicon-eye-close"></i> Unwatch</button>
+    <button type="button" class="btn btn-primary"
+            ng-click="bulkAckAlert(bulkAlerts)"
+            ng-disabled="status.indexOf('ack') > -1"><i class="glyphicon glyphicon-ok-circle"></i> Ack</button>
+    <button type="button" class="btn btn-warning"
+            ng-click="bulkCloseAlert(bulkAlerts)"
+            ng-disabled="status.indexOf('closed') > -1"><i class="glyphicon glyphicon-remove-circle"></i> Close</button>
+    <button type="button" class="btn btn-danger"
+            ng-click="bulkDeleteAlert(bulkAlerts)"><i class="glyphicon glyphicon-trash"></i> Delete</button>
+  </div>
+  </div>
 </div> <!-- container -->

--- a/app/partials/alert-watch.html
+++ b/app/partials/alert-watch.html
@@ -19,7 +19,7 @@
 
         <tr ng-repeat="alert in watches | orderBy:predicate:reverse"
             ng-style="{ 'color':  colors.severity[alert.severity] == 'black' ? 'white' : colors.text, 'background-color': colors.severity[alert.severity] }"
-            ng-controller="AlertLinkController" ng-click="getDetails(alert);">
+            ng-click="getDetails(alert);">
           <td class="hidden-xs"><i class="glyphicon glyphicon-{{ alert.trendIndication | arrow }}"></i>&nbsp;<span class="label label-{{ alert.severity }}">{{ alert.severity | capitalize }}</span></td>
           <td class="hidden-xs"><span class="label label-{{ alert.status }}">{{ alert.status | capitalize }}</span></td>
           <td class="hidden-lg">{{ alert.lastReceiveTime | date:'HH:mm' }}</td>


### PR DESCRIPTION
On Mac OS X, command-click to select multiple alerts from the recent alerts list and then bulk action buttons will appear at the bottom of the web page. On Windows, use alt-click.

Fixes guardian/alerta#114