### PR TITLE
Bugfix for launching web UI on heroku

### DIFF
--- a/web.js
+++ b/web.js
@@ -11,7 +11,7 @@ app.get('/config.js', function(request, response) {
         'provider'    : '" + process.env.PROVIDER + "', \
         'client_id'   : '" + process.env.CLIENT_ID + "', \
         'gitlab_url'  : '" + process.env.GITLAB_URL + "' \
-      }); \
+      });";
 
   response.send(config);
 });


### PR DESCRIPTION
```
2016-02-21T23:38:15.510338+00:00 heroku[web.1]: Starting process with command `node web.js`
2016-02-21T23:38:17.398897+00:00 app[web.1]:
2016-02-21T23:38:17.399248+00:00 app[web.1]: /app/web.js:13
2016-02-21T23:38:17.399561+00:00 app[web.1]:         'gitlab_url'  : '" + process.env.GITLAB_URL + "' \
2016-02-21T23:38:17.399637+00:00 app[web.1]:                                                       ^^^^^^^^^^^^^^^^^
2016-02-21T23:38:17.403292+00:00 app[web.1]: SyntaxError: Unexpected token ILLEGAL
2016-02-21T23:38:17.403293+00:00 app[web.1]:     at Module._compile (module.js:439:25)
2016-02-21T23:38:17.403295+00:00 app[web.1]:     at Module.load (module.js:356:32)
2016-02-21T23:38:17.403294+00:00 app[web.1]:     at Object.Module._extensions..js (module.js:474:10)
2016-02-21T23:38:17.403297+00:00 app[web.1]:     at node.js:935:3
2016-02-21T23:38:17.403296+00:00 app[web.1]:     at Function.Module._load (module.js:312:12)
2016-02-21T23:38:17.403296+00:00 app[web.1]:     at Function.Module.runMain (module.js:497:10)
2016-02-21T23:38:17.403297+00:00 app[web.1]:     at startup (node.js:119:16)
2016-02-21T23:38:18.162493+00:00 heroku[web.1]: State changed from starting to crashed
2016-02-21T23:38:18.151207+00:00 heroku[web.1]: Process exited with status 8
```