### PR TITLE
Make severity code sort order configurable

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -7,5 +7,6 @@ angular.module('config', [])
     'client_id'   : "INSERT-CLIENT-ID-HERE",
     'gitlab_url'  : "https://gitlab.com",  // replace with your gitlab server
     'colors'      : {}, // use default colors
+    'severity'    : {}, // use default severity codes
     'audio'       : {}  // no audio
   });

--- a/app/config.js.example
+++ b/app/config.js.example
@@ -9,6 +9,7 @@ angular.module('config', [])
 
     'colors'      : {
       'severity': {
+        'fatal'        : '#000000',  // black
         'critical'     : '#D8122A',
         'major'        : '#EA680F',
         'minor'        : '#FFBE1E',
@@ -25,7 +26,9 @@ angular.module('config', [])
       'text': 'white',
       'highlight': 'lightgray'
     },
-
+    'severity'    : {
+      'fatal': 0
+    },
     'audio'       : {
       'new'  : '/audio/Bike Horn.mp3'
     }

--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -71,7 +71,7 @@ alertaControllers.controller('AlertListController', ['$scope', '$route', '$locat
       return $auth.isAuthenticated();
     };
 
-    var defaults = {
+    var colorDefaults = {
       severity: {
         critical: 'red',
         major: 'orange',
@@ -90,7 +90,7 @@ alertaControllers.controller('AlertListController', ['$scope', '$route', '$locat
       highlight: 'skyblue '
     };
 
-    $scope.colors = angular.merge(defaults, config.colors);
+    $scope.colors = angular.merge(colorDefaults, config.colors);
 
     $scope.autoRefresh = true;
     $scope.refreshText = 'Auto Update';
@@ -200,27 +200,29 @@ alertaControllers.controller('AlertListController', ['$scope', '$route', '$locat
       }
     });
 
-    var SEVERITY_MAP = {
-        'critical': 1,
-        'major': 2,
-        'minor': 3,
-        'warning': 4,
-        'indeterminate': 5,
-        'cleared': 5,
-        'normal': 5,
-        'ok': 5,
-        'informational': 6,
-        'debug': 7,
-        'security': 8,
-        'unknown': 9
+    var severityCodeDefaults = {
+      critical: 1,
+      major: 2,
+      minor: 3,
+      warning: 4,
+      indeterminate: 5,
+      cleared: 5,
+      normal: 5,
+      ok: 5,
+      informational: 6,
+      debug: 7,
+      security: 8,
+      unknown: 9
     };
 
+    var severityCodes = angular.merge(severityCodeDefaults, config.severity);
+
     $scope.reverseSeverityCode = function(alert) {
-      return -SEVERITY_MAP[alert.severity];
+      return -severityCodes[alert.severity];
     };
 
     $scope.severityCode = function(alert) {
-      return SEVERITY_MAP[alert.severity];
+      return severityCodes[alert.severity];
     };
 
     $scope.audio = config.audio;


### PR DESCRIPTION
In `config.js` list all the new severity codes in the `severity` section (note: **not** the `colors.severity` section) format:

```
'use strict';

angular.module('config', [])
  .constant('config', {
    'endpoint'    : "http://"+window.location.hostname+":8080",
    'provider'    : "basic", // google, github, gitlab or basic
    'client_id'   : "INSERT-CLIENT-ID-HERE",
    'gitlab_url'  : "https://gitlab.com",  // for gitlab provider only

    'colors'      : {
      'severity': {
        'BLOCKING'     : '#D8122A',
        'ERROR'        : '#EA680F',
        'DISABLED'     : '#FFBE1E',
        'configuring'  : '#A6ACA8',
        'waiting'      : '#00AA5A',
        'ready'        : '#00AA5A',
        'negotiating'  : '#00AA5A',
        'authenticated': '#00AA5A',
        'active'       : '#00A1BC',
        'security'     : '#333333',
        'unknown'      : '#BA2222'
      },
      'text': 'white',
      'highlight': 'lightgray'
    },
    'severity'    : {
      'BLOCKING'     : 1,
      'ERROR'        : 2,
      'DISABLED'     : 3,
      'configuring'  : 4,
      'waiting'      : 5,
      'ready'        : 5,
      'negotiating'  : 5,
      'authenticated': 5,
      'active'       : 6,
      'security'     : 8,
      'unknown'      : 9
    },
    'audio'       : {
      'new'  : '/audio/Bike Horn.mp3'
    }
  });
```

See related server code change https://github.com/guardian/alerta/pull/163