### PR TITLE
Make dates configurable for short, medium and long formats

### DIFF
--- a/app/config.js.example
+++ b/app/config.js.example
@@ -29,6 +29,11 @@ angular.module('config', [])
     'severity'    : {
       'fatal': 0
     },
+    'dates': {
+      'shortTime' : 'shortTime',  // 1:39 PM
+      'mediumDate': 'medium', // Apr 26, 2016 1:39:44 PM
+      'longDate'  : 'EEEE, MMMM d, yyyy h:mm:ss.sss a (Z)'  // Tuesday, April 26, 2016 1:39:43.987 PM (+0100)
+    },
     'audio'       : {
       'new'  : '/audio/Bike Horn.mp3'
     }

--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -303,10 +303,13 @@ alertaControllers.controller('AlertListController', ['$scope', '$route', '$locat
       });
       $route.reload();
     };
+
+    $scope.shortTime = config.dates && config.dates.shortTime || 'HH:mm';
+    $scope.mediumDate = config.dates && config.dates.mediumDate || 'EEE d MMM HH:mm';
   }]);
 
-alertaControllers.controller('AlertDetailController', ['$scope', '$route', '$routeParams', '$location', '$auth', 'Alert',
-  function($scope, $route, $routeParams, $location, $auth, Alert){
+alertaControllers.controller('AlertDetailController', ['$scope', '$route', '$routeParams', '$location', '$auth', 'config', 'Alert',
+  function($scope, $route, $routeParams, $location, $auth, config, Alert){
 
     var byUser = '';
     if ($auth.isAuthenticated()) {
@@ -375,6 +378,8 @@ alertaControllers.controller('AlertDetailController', ['$scope', '$route', '$rou
       });
     };
 
+    $scope.shortTime = config.dates && config.dates.shortTime || 'HH:mm';
+    $scope.longDate = config.dates && config.dates.longDate || 'd/M/yyyy h:mm:ss.sss a';
   }]);
 
 alertaControllers.controller('AlertTop10Controller', ['$scope', '$location', '$timeout', 'Count', 'Environment', 'Service', 'Alert',
@@ -613,10 +618,13 @@ alertaControllers.controller('AlertWatchController', ['$scope', '$route', '$loca
       });
       $route.reload();
     };
+
+    $scope.shortTime = config.dates && config.dates.shortTime || 'HH:mm';
+    $scope.mediumDate = config.dates && config.dates.mediumDate || 'EEE d MMM HH:mm';
   }]);
 
-alertaControllers.controller('AlertBlackoutController', ['$scope', '$route', '$timeout', '$auth', 'Blackouts', 'Environment', 'Service', 'Customers',
-  function($scope, $route, $timeout, $auth, Blackouts, Environment, Service, Customers) {
+alertaControllers.controller('AlertBlackoutController', ['$scope', '$route', '$timeout', '$auth', 'config', 'Blackouts', 'Environment', 'Service', 'Customers',
+  function($scope, $route, $timeout, $auth, config, Blackouts, Environment, Service, Customers) {
 
     $scope.blackouts = [];
 
@@ -658,6 +666,7 @@ alertaControllers.controller('AlertBlackoutController', ['$scope', '$route', '$t
       $scope.blackouts = response.blackouts;
     });
 
+    $scope.mediumDate = config.dates && config.dates.mediumDate || 'EEE d MMM HH:mm';
   }]);
 
 
@@ -702,6 +711,7 @@ alertaControllers.controller('UserController', ['$scope', '$route', '$timeout', 
       $scope.users = response.users;
     });
 
+    $scope.longDate = config.dates && config.dates.longDate || 'd/M/yyyy h:mm:ss.sss a';
   }]);
 
 alertaControllers.controller('CustomerController', ['$scope', '$route', '$timeout', '$auth', 'Customers',
@@ -729,8 +739,8 @@ alertaControllers.controller('CustomerController', ['$scope', '$route', '$timeou
 
   }]);
 
-alertaControllers.controller('ApiKeyController', ['$scope', '$route', '$timeout', '$auth', 'Keys',
-  function($scope, $route, $timeout, $auth, Keys) {
+alertaControllers.controller('ApiKeyController', ['$scope', '$route', '$timeout', '$auth', 'config', 'Keys',
+  function($scope, $route, $timeout, $auth, config, Keys) {
 
     $scope.isAdmin = function() {
       if ($auth.isAuthenticated()) {
@@ -761,6 +771,8 @@ alertaControllers.controller('ApiKeyController', ['$scope', '$route', '$timeout'
     Keys.query({}, function(response) {
       $scope.keys = response.keys;
     });
+
+    $scope.longDate = config.dates && config.dates.longDate || 'd/M/yyyy h:mm:ss.sss a';
   }]);
 
 alertaControllers.controller('ProfileController', ['$scope', '$auth',
@@ -777,8 +789,8 @@ alertaControllers.controller('ProfileController', ['$scope', '$auth',
     $scope.payload = $auth.getPayload();
   }]);
 
-alertaControllers.controller('AboutController', ['$scope', '$timeout', 'Management', 'Heartbeat',
-  function($scope, $timeout, Management, Heartbeat) {
+alertaControllers.controller('AboutController', ['$scope', '$timeout', 'config', 'Management', 'Heartbeat',
+  function($scope, $timeout, config, Management, Heartbeat) {
 
     Management.manifest(function(response) {
       $scope.manifest = response;
@@ -806,6 +818,7 @@ alertaControllers.controller('AboutController', ['$scope', '$timeout', 'Manageme
       }
     });
 
+    $scope.longDate = config.dates && config.dates.longDate || 'd/M/yyyy h:mm:ss.sss a';
   }]);
 
 alertaControllers.controller('LoginController', ['$scope', '$rootScope', '$location', '$auth', 'config',

--- a/app/partials/about.html
+++ b/app/partials/about.html
@@ -51,8 +51,8 @@
             class="heartbeat heartbeat-stale">
           <td>{{ heartbeat.origin }}</td>
           <td class="hidden-xs"><span ng-repeat="tag in heartbeat.tags"><span class="label label-primary">{{ tag }}</span> </span></td>
-          <td class="hidden-xs">{{ heartbeat.createTime | date:'EEE&nbsp;d&nbsp;MMM&nbsp;HH:mm:ss' }}</td>
-          <td class="hidden-xs">{{ heartbeat.receiveTime | date:'EEE&nbsp;d&nbsp;MMM&nbsp;HH:mm:ss' }}</td>
+          <td class="hidden-xs">{{ heartbeat.createTime | date:longDate }}</td>
+          <td class="hidden-xs">{{ heartbeat.receiveTime | date:longDate }}</td>
           <td>{{ heartbeat.receiveTime | diff:heartbeat.createTime }} ms</td>
           <td class="hidden-xs">{{ heartbeat.timeout }} seconds</td>
           <td>{{ heartbeat.receiveTime | since }}</td>
@@ -62,7 +62,7 @@
       <div>
         <table class="table">
           <tr>
-            <td><b>Last Update</b></td><td>{{ lastTime | date:'EEE&nbsp;d&nbsp;MMM&nbsp;HH:mm:ss'}}</td>
+            <td><b>Last Update</b></td><td>{{ lastTime | date:longDate }}</td>
             <td><b>Uptime</b></td><td>{{ uptime / 1000 | hms }}</td>
           </tr>
         </table>

--- a/app/partials/alert-details.html
+++ b/app/partials/alert-details.html
@@ -30,9 +30,9 @@
   <tr class="visible-xs"><td><b>Last Receive Alert ID</b></td><td>{{ alert.lastReceiveId | shortid }}</td></tr>
   <tr class="hidden-xs"><td><b>Alert ID</b></td><td>{{ alert.id }}</td></tr>
   <tr class="hidden-xs"><td><b>Last Receive Alert ID</b></td><td>{{ alert.lastReceiveId }}</td></tr>
-  <tr><td><b>Create Time</b></td><td>{{ alert.createTime | date:'d/M/yyyy h:mm:ss.sss a' }} ({{ alert.createTime | relativeDate }})</td></tr>
-  <tr><td><b>Receive Time</b></td><td>{{ alert.receiveTime | date:'d/M/yyyy h:mm:ss.sss a' }} ({{ alert.receiveTime | relativeDate }})</td></tr>
-  <tr><td><b>Last Receive Time</b></td><td>{{ alert.lastReceiveTime | date:'d/M/yyyy h:mm:ss.sss a' }} ({{ alert.lastReceiveTime | relativeDate }})</td></tr>
+  <tr><td><b>Create Time</b></td><td>{{ alert.createTime | date:longDate }} ({{ alert.createTime | relativeDate }})</td></tr>
+  <tr><td><b>Receive Time</b></td><td>{{ alert.receiveTime | date:longDate }} ({{ alert.receiveTime | relativeDate }})</td></tr>
+  <tr><td><b>Last Receive Time</b></td><td>{{ alert.lastReceiveTime | date:longDate }} ({{ alert.lastReceiveTime | relativeDate }})</td></tr>
   <tr ng-show="isCustomerViews();"><td><b>Customer</b></td><td>{{ alert.customer }}</td></tr>
   <tr><td><b>Service</b></td><td>{{ alert.service.join(', ') }}</td></tr>
   <tr><td><b>Environment</b></td><td>{{ alert.environment }}</td></tr>
@@ -85,8 +85,8 @@
   <tr ng-repeat="history in alert.history | orderBy:'updateTime':true">
     <td class="hidden-lg">{{ history.id | shortid }}</td>
     <td class="visible-lg">{{ history.id }}</td>
-    <td class="visible-xs">{{ history.updateTime | date:'HH:mm' }}</td>
-    <td class="hidden-xs">{{ history.updateTime | date:'d/M/yyyy h:mm:ss.sss a' }}</td>
+    <td class="visible-xs">{{ history.updateTime | date:shortTime }}</td>
+    <td class="hidden-xs">{{ history.updateTime | date:longDate }}</td>
     <td><span class="label label-{{ history.status || history.severity }}">{{ history.status || history.severity | capitalize }}</span></td>
     <td>{{ history.event }}</td>
     <td class="hidden-xs">{{ history.value }}</td>

--- a/app/partials/alert-list.html
+++ b/app/partials/alert-list.html
@@ -54,8 +54,8 @@
             ng-click="click($event,alert);">
           <td class="hidden-xs no-wrap"><i class="glyphicon glyphicon-{{ alert.trendIndication | arrow }}"></i>&nbsp;<span class="label label-{{ alert.severity }}">{{ alert.severity | capitalize }}</span></td>
           <td class="hidden-xs"><span class="label label-{{ alert.status }}">{{ alert.status | capitalize }}</span></td>
-          <td class="hidden-lg">{{ alert.lastReceiveTime | date:'HH:mm' }}</td>
-          <td class="visible-lg">{{ alert.lastReceiveTime | date:'EEE&nbsp;d&nbsp;MMM&nbsp;HH:mm' }}</td>
+          <td class="hidden-lg">{{ alert.lastReceiveTime | date:shortTime }}</td>
+          <td class="visible-lg">{{ alert.lastReceiveTime | date:mediumDate }}</td>
           <td class="visible-lg">{{ alert.duplicateCount }}</td>
           <td class="hidden-xs" ng-show="isCustomerViews() && isAdmin();">{{ alert.customer }}</td>
           <td class="hidden-xs">{{ alert.environment }}</td>

--- a/app/partials/alert-watch.html
+++ b/app/partials/alert-watch.html
@@ -22,8 +22,8 @@
             ng-click="click($event,alert);">
           <td class="hidden-xs"><i class="glyphicon glyphicon-{{ alert.trendIndication | arrow }}"></i>&nbsp;<span class="label label-{{ alert.severity }}">{{ alert.severity | capitalize }}</span></td>
           <td class="hidden-xs"><span class="label label-{{ alert.status }}">{{ alert.status | capitalize }}</span></td>
-          <td class="hidden-lg">{{ alert.lastReceiveTime | date:'HH:mm' }}</td>
-          <td class="visible-lg">{{ alert.lastReceiveTime | date:'EEE&nbsp;d&nbsp;MMM&nbsp;HH:mm' }}</td>
+          <td class="hidden-lg">{{ alert.lastReceiveTime | date:shortTime }}</td>
+          <td class="visible-lg">{{ alert.lastReceiveTime | date:mediumDate }}</td>
           <td class="visible-lg">{{ alert.duplicateCount }}</td>
           <td class="hidden-xs">{{ alert.environment }}</td>
           <td class="hidden-xs">{{ alert.service.join(', ') }}</td>

--- a/app/partials/blackouts.html
+++ b/app/partials/blackouts.html
@@ -28,8 +28,8 @@
           <td>{{ blackout.group }}</td>
           <td><span ng-repeat="tag in blackout.tags"><span class="label label-primary">{{ tag }}</span> </span></td>
           <td><i class="glyphicon glyphicon-time" ng-show="blackout.status == 'pending'" title="Pending"></i><i class="glyphicon glyphicon-exclamation-sign" ng-show="blackout.status == 'active'" title="Active"></i><i class="glyphicon glyphicon-ban-circle" ng-show="blackout.status == 'expired'" title="Expired"></i></td>
-          <td class="hidden-xs">{{ blackout.startTime | date:'EEE&nbsp;d&nbsp;MMM&nbsp;HH:mm:ss' }}</td>
-          <td class="hidden-xs">{{ blackout.endTime | date:'EEE&nbsp;d&nbsp;MMM&nbsp;HH:mm:ss' }}</td>
+          <td class="hidden-xs">{{ blackout.startTime | date:mediumDate }}</td>
+          <td class="hidden-xs">{{ blackout.endTime | date:mediumDate }}</td>
           <td>{{ blackout.remaining | hms }}</td>
           <td><button type="button" class="btn btn-default btn-sm" ng-click="deleteBlackout(blackout.id);"><i class="glyphicon glyphicon-trash"></i> Delete</button></td>
         </tr>

--- a/app/partials/keys.html
+++ b/app/partials/keys.html
@@ -24,9 +24,9 @@
           <td class="hidden-xs">{{ key.text }}</td>
           <td class="hidden-xs" ng-show="isCustomerViews();">{{ key.customer }}</td>
           <td class="hidden-xs">{{ key.type }}</td>
-          <td class="hidden-xs">{{ key.expireTime | date:'EEE&nbsp;d&nbsp;MMM&nbsp;HH:mm:ss&nbsp;yyyy' }}</td>
+          <td class="hidden-xs">{{ key.expireTime | date:longDate }}</td>
           <td><i class="glyphicon glyphicon-warning-sign" ng-show="key.expireTime | isExpired" title="Expired"></i><i class="glyphicon glyphicon-ok" ng-hide="key.expireTime | isExpired" title="Active"></i></td>
-          <td class="hidden-xs">{{ key.lastUsedTime | date:'EEE&nbsp;d&nbsp;MMM&nbsp;HH:mm:ss&nbsp;yyyy' }}</td>
+          <td class="hidden-xs">{{ key.lastUsedTime | date:longDate }}</td>
           <td class="hidden-xs">{{ key.count }}</td>
           <td><button type="button" class="btn btn-default btn-sm" ng-click="deleteKey(key.key);"><i class="glyphicon glyphicon-trash"></i> Revoke</button></td>
         </tr>

--- a/app/partials/users.html
+++ b/app/partials/users.html
@@ -30,7 +30,7 @@
         <tr ng-repeat="user in users">
           <td>{{ user.name }}</td>
           <td>{{ user.login }}</td>
-          <td class="hidden-xs">{{ user.createTime | date:'EEE&nbsp;d&nbsp;MMM&nbsp;HH:mm:ss&nbsp;yyyy' }}</td>
+          <td class="hidden-xs">{{ user.createTime | date:longDate }}</td>
           <td class="hidden-xs">{{ user.provider }}</td>
           <td class="hidden-xs">{{ user.text }}</td>
           <td><button type="button" class="btn btn-default btn-sm" ng-click="deleteUser(user.id);"><i class="glyphicon glyphicon-trash"></i> Revoke</button></td>


### PR DESCRIPTION
**Defaults**
```
shortTime: 'HH:mm'
mediumDate: 'EEE d MMM HH:mm'
longDate: 'd/M/yyyy h:mm:ss.sss a'
```
See https://docs.angularjs.org/api/ng/filter/date for full list of date formats

**Example**
```
angular.module('config', [])
  .constant('config', {
    'endpoint'    : "http://"+window.location.hostname+":8080",
    'provider'    : "basic", // google, github, gitlab or basic
    'dates': {
      'shortTime' : 'shortTime',  // 1:39 PM
      'mediumDate': 'medium', // Apr 26, 2016 1:39:44 PM
      'longDate'  : 'EEEE, MMMM d, yyyy h:mm:ss.sss a (Z)'  // Tuesday, April 26, 2016 1:39:43.987 PM (+0100)
    }
  });
```