### PR TITLE
Change the way in which alert rows are styled

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -6,7 +6,61 @@ angular.module('config', [])
     'provider'    : "basic", // google, github, gitlab or basic
     'client_id'   : "INSERT-CLIENT-ID-HERE",
     'gitlab_url'  : "https://gitlab.com",  // replace with your gitlab server
-    'colors'      : {}, // use default colors
+    'colors'      : {}, // use default colors, remove colors_css property below to use it
+    // alternative way of overriding colors
+    'colors_css': `
+      .alert-row-critical {
+        background-color: red;
+        color: white;
+      }
+      .alert-row-major {
+        background-color: orange;
+        color: black;
+      }
+      .alert-row-minor {
+        background-color: yellow;
+        color: black;
+      }
+      .alert-row-warning {
+        background-color: #1E90FF;
+        color: white;
+      }
+      .alert-row-indeterminate {
+        background-color: silver;
+        color: black;
+      }
+      .alert-row-cleared {
+        background-color: #00CC00;
+        color: black;
+      }
+      .alert-row-normal {
+        background-color: #00CC00;
+        color: black;
+      }
+      .alert-row-ok {
+        background-color: #00CC00;
+        color: black;
+      }
+      .alert-row-informational {
+        background-color: #00CC00;
+        color: black;
+      }
+      .alert-row-debug {
+        background-color: #7554BF;
+        color: white;
+      }
+      .alert-row-security {
+        background-color: black;
+        color: white;
+      }
+      .alert-row-unknown {
+        background-color: silver;
+        color: black;
+      }
+      .alert-row-highlighted {
+        background-color: skyblue;
+        color: black;
+      }`,
     'severity'    : {}, // use default severity codes
     'audio'       : {}, // no audio
     'tracking_id' : ""  // Google Analytics tracking ID eg. UA-NNNNNN-N

--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -71,26 +71,39 @@ alertaControllers.controller('AlertListController', ['$scope', '$route', '$locat
       return $auth.isAuthenticated();
     };
 
-    var colorDefaults = {
-      severity: {
-        critical: 'red',
-        major: 'orange',
-        minor: 'yellow',
-        warning: '#1E90FF',
-        indeterminate: 'silver',
-        cleared: '#00CC00',
-        normal: '#00CC00',
-        ok: '#00CC00',
-        informational: '#00CC00',
-        debug: '#7554BF',
-        security: 'black',
-        unknown: 'silver'
-      },
-      text: 'black',
-      highlight: 'skyblue '
-    };
+    if (config.colors_css) {
+      $scope.color_css = config.colors_css;
+    } else {
+      var colorDefaults = {
+        severity: {
+          critical: 'red',
+          major: 'orange',
+          minor: 'yellow',
+          warning: '#1E90FF',
+          indeterminate: 'silver',
+          cleared: '#00CC00',
+          normal: '#00CC00',
+          ok: '#00CC00',
+          informational: '#00CC00',
+          debug: '#7554BF',
+          security: 'black',
+          unknown: 'silver'
+        },
+        text: 'black',
+        highlight: 'skyblue'
+      };
 
-    $scope.colors = angular.merge(colorDefaults, config.colors);
+      var colors = angular.merge(colorDefaults, config.colors);
+      var css_lines = [];
+      Object.keys(colors.severity).forEach(function (severity) {
+        css_lines.push('.alert-row-'+severity+' {\n' +
+          'background-color: '+colors.severity[severity] +';\n' +
+          'color: '+(colors.severity[severity] == 'black' ? 'white' : colors.text)+';\n' +
+        '}')
+      });
+      css_lines.push('.alert-row-highlighted {background-color: '+colors.highlight+'; }');
+      $scope.color_css = css_lines.join('\n');
+    }
 
     $scope.autoRefresh = true;
     $scope.refreshText = 'Auto Update';

--- a/app/partials/alert-list.html
+++ b/app/partials/alert-list.html
@@ -1,6 +1,7 @@
 
 
 <div class="container-fluid">
+  <style type="text/css">{{color_css}}</style>
 
   <div class="row">
     <div class="col-md-3 col-sm-3 col-xs-12">
@@ -49,8 +50,8 @@
           <th class="hidden-xs"><a href="" ng-click="predicate = 'text'; reverse=!reverse">Text&nbsp;<span ng-hide="predicate != 'text'"><span ng-show="!reverse">^</span><span ng-show="reverse">v</span></span></a></th>
         </tr>
 
-        <tr ng-repeat="alert in alerts | filter:search | orderBy:predicate:reverse | limitTo:alertLimit"
-            ng-style="{ 'color':  colors.severity[alert.severity] == 'black' ? 'white' : colors.text, 'background-color': (bulkAlerts.indexOf(alert.id) > -1) ? colors.highlight : colors.severity[alert.severity] || 'silver' }"
+        <tr class="{{'alert-row alert-row-' + alert.severity + ((bulkAlerts.indexOf(alert.id) > -1) ? ' alert-row-highlighted' : '')}}"
+            ng-repeat="alert in alerts | filter:search | orderBy:predicate:reverse | limitTo:alertLimit"
             ng-click="click($event,alert);">
           <td class="hidden-xs no-wrap"><i class="glyphicon glyphicon-{{ alert.trendIndication | arrow }}"></i>&nbsp;<span class="label label-{{ alert.severity }}">{{ alert.severity | capitalize }}</span></td>
           <td class="hidden-xs"><span class="label label-{{ alert.status }}">{{ alert.status | capitalize }}</span></td>


### PR DESCRIPTION
Before: each alert <tr> was styled with ng-style which picked it's style depending on severity

After: each severity has it's own css class
it's possible to set arbitrary css for alert rows in config

pros:
- it's possible to style each severity more flexibly (eg. to have special text and background colors, not only background)
- it's better works with browser extensions which modify webpages styles
