### PR TITLE
Fix permission validation.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -31,7 +31,8 @@
         <li ng-show="hasPermission('read:alerts')" ng-class="{active: isActive('/watch')}" ng-show="isAuthenticated();"><a href="#/watch">Watch</a></li>
       </ul>
       <ul class="nav navbar-nav navbar-right">
-        <li ng-show="hasPermission('read:blackouts')" class="dropdown"><a href="" class="dropdown-toggle" data-toggle="dropdown">Configuration <span class="caret"></span></a>
+        <li ng-show="hasPermission('read:blackouts admin:users admin:perms admin:customers read:keys read:blackouts')"
+            class="dropdown"><a href="" class="dropdown-toggle" data-toggle="dropdown">Configuration <span class="caret"></span></a>
           <ul class="dropdown-menu" role="menu">
             <li ng-show="hasPermission('admin:users')"><a href="#/users">Users</a></li>
             <li ng-show="hasPermission('admin:perms')"><a href="#/perms">Permissions</a></li>

--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -31,7 +31,8 @@ alertaControllers.controller('MenuController', ['$scope', '$location', '$auth', 
       }
     };
 
-    $scope.hasPermission = function(perm) {
+    $scope.hasPermission = function(perms) {
+
       function isInScope(scope) {
         var scopes = $auth.isAuthenticated() ? ($auth.getPayload().scope || '').split(' ') : [];
         if (scopes.includes(scope) || scopes.includes(scope.split(':')[0])) {
@@ -45,12 +46,13 @@ alertaControllers.controller('MenuController', ['$scope', '$location', '$auth', 
 
       if ($auth.isAuthenticated()) {
         var scopes = ($auth.getPayload().scope || '').split(' ');
-        if (scopes.includes(perm) || scopes.includes(perm.split(':')[0])) {
+        perms = perms.split(' ') || [];
+        if (perms.some(function (perm) { return (scopes.includes(perm) || scopes.includes(perm.split(':')[0])) })) {
           return true;
-        } else if (perm.startsWith('read')) {
-          return isInScope(perm.replace('read', 'write'));
-        } else if (perm.startsWith('write')) {
-          return isInScope(perm.replace('write', 'admin'))
+        } else if (perms.some(function (perm) { return perm.startsWith('read') })) {
+          return isInScope(perms.replace('read', 'write'));
+        } else if (perms.some(function (perm) { return perm.startsWith('write') })) {
+          return isInScope(perms.replace('write', 'admin'))
         }
       } else {
         return false;


### PR DESCRIPTION
Fix permission validation for the dropdown menu.
If you define role permission, `admin:customers` for example, the `Configuration` dropdown menu didn't appear. It solve these cases.