### PR TITLE
Adding configuration for setting the auto-refresh interval

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -13,5 +13,6 @@ angular.module('config', [])
     'colors'          : {}, // use default colors
     'severity'        : {}, // use default severity codes
     'audio'           : {}, // no audio
-    'tracking_id'     : ""  // Google Analytics tracking ID eg. UA-NNNNNN-N
+    'tracking_id'     : "", // Google Analytics tracking ID eg. UA-NNNNNN-N
+    'refresh_interval': 5000 // Auto-refresh interval, defaults to 5 seconds. 
   });

--- a/app/config.js.example
+++ b/app/config.js.example
@@ -38,5 +38,6 @@ angular.module('config', [])
     'audio'       : {
       'new'  : '/audio/Bike Horn.mp3'
     },
-    'tracking_id': 'UA-NNNNNN-N'
+    'tracking_id': 'UA-NNNNNN-N',
+    'refresh_interval': 30000 // Auto-refresh interval set to 30 seconds 
   });

--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -251,7 +251,7 @@ alertaControllers.controller('AlertListController', ['$scope', '$route', '$locat
       if ($scope.autoRefresh) {
         refresh();
       }
-      timer = $timeout(refreshWithTimeout, 5000);
+      timer = $timeout(refreshWithTimeout, config.refresh_interval);
     };
     var timer = $timeout(refreshWithTimeout, 200);
 


### PR DESCRIPTION
This PR adds support for defining the auto-refresh interval via config.js

It does not add the use of config for auto-refresh on "top10", nor on "watch" as the codepath for auto-refresh there seemed inactive. If I am mistaken, or if this also should be implemented there then please say so, and I'll change my PR to match!