### PR TITLE
Added support for batch-opening alarms in new tabs as well as ctrl+cl…

### DIFF
--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -306,8 +306,10 @@ alertaControllers.controller('AlertListController', ['$scope', '$route', '$locat
         } else {
           $scope.bulkAlerts.push(alert.id);
         }
-      } else {
+      } else if(!$event.ctrlKey){
         $location.url('/alert/' + alert.id);
+    } else ($event.ctrlKey) {
+        window.open('/#/alert' + alert.id, '_blank');
       }
     };
 
@@ -369,6 +371,12 @@ alertaControllers.controller('AlertListController', ['$scope', '$route', '$locat
         });
       });
       $route.reload();
+    };
+
+    $scope.bulkOpenTabAlert = function(ids) {
+      angular.forEach(ids, function(id) {
+        window.open('/#/alert/' + id, '_blank');
+      });
     };
 
     $scope.shortTime = config.dates && config.dates.shortTime || 'HH:mm';
@@ -718,6 +726,12 @@ alertaControllers.controller('AlertWatchController', ['$scope', '$route', '$loca
         });
       });
       $route.reload();
+    };
+
+    $scope.bulkOpenTabAlert = function(ids) {
+      angular.forEach(ids, function(id) {
+        window.open('/#/alert/' + id, '_blank');
+      });
     };
 
     $scope.shortTime = config.dates && config.dates.shortTime || 'HH:mm';

--- a/app/partials/alert-list.html
+++ b/app/partials/alert-list.html
@@ -91,6 +91,9 @@
     <button ng-disabled="!hasPermission('write:alerts')" type="button" class="btn btn-success"
             ng-click="bulkUnackAlert(bulkAlerts)"
             ng-disabled="status.indexOf('open') > -1"><i class="glyphicon glyphicon-arrow-up"></i> Open</button>
+    <button ng-disabled="!hasPermission('write:alerts')" type="button" class="btn btn-default"
+            ng-click="bulkOpenTabAlert(bulkAlerts)"
+            ng-disabled="status.indexOf('open') > -1"><i class="glyphicon glyphicon-plus"></i> Open in new Tab</button>
     <!-- button ng-disabled"!hasPermission('write:alerts')" type="button" class="btn btn-default"
             ng-click="bulkTagAlert(alert.id, ['foo'])">Tag</button -->
     <button ng-disabled="!hasPermission('write:alerts')" type="button" class="btn btn-default"


### PR DESCRIPTION
Support for batch opening alarms in new tabs + ctrl clicking alarms to open them in a new tab.
I'm not sure if this is the best approach on implementing this feature, but here's my go at it.

Let me know if there's anything I need to change.