### PR TITLE
Add the ability to filter by Mongo query directly

### DIFF
--- a/app/config.js.example
+++ b/app/config.js.example
@@ -39,5 +39,6 @@ angular.module('config', [])
       'new'  : '/audio/Bike Horn.mp3'
     },
     'tracking_id': 'UA-NNNNNN-N',
-    'refresh_interval': 30000 // Auto-refresh interval set to 30 seconds
+    'refresh_interval': 30000, // Auto-refresh interval set to 30 seconds
+    'backend_db'  : "postgresql" // Optional: backend alerta database. Either "postgresql" or "mongodb"
   });

--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -151,6 +151,9 @@ alertaControllers.controller('AlertListController', ['$scope', '$route', '$locat
     if (search.service) {
       $scope.service = search.service;
     }
+    if (search.q) {
+      $scope.mongoQuery = search.q;
+    }
 
     $scope.show = [
       {name: 'Open', value: ['open', 'unknown']},
@@ -166,10 +169,13 @@ alertaControllers.controller('AlertListController', ['$scope', '$route', '$locat
       $scope.status = $scope.show[0];
     }
 
+    $scope.APIError = false;
+    $scope.APIErrorResponse = null;
     $scope.alerts = [];
     $scope.alertLimit = 20;
     $scope.reverse = true;
     $scope.query = {};
+    $scope.showMongoQueryForm = 'backend_db' in config && config.backend_db == "mongodb"
 
     $scope.setService = function(s) {
       if (s) {
@@ -214,6 +220,11 @@ alertaControllers.controller('AlertListController', ['$scope', '$route', '$locat
       } else {
         delete $scope.query['status'];
       }
+      if ($scope.mongoQuery) {
+        $scope.query['q'] = $scope.mongoQuery;
+      } else {
+        delete $scope.query['q'];
+      }
       $location.search($scope.query);
     };
 
@@ -234,7 +245,8 @@ alertaControllers.controller('AlertListController', ['$scope', '$route', '$locat
         $scope.environments = response.environments;
       });
       updateQuery();
-      Alert.query($scope.query, function(response) {
+      var success = function(response) {
+        $scope.APIError = false;
         if (response.status == 'ok') {
           $scope.alerts = response.alerts;
         }
@@ -245,7 +257,16 @@ alertaControllers.controller('AlertListController', ['$scope', '$route', '$locat
         } else {
           $scope.refreshText = 'Refresh';
         }
-      });
+      }
+      var error = function(response) {
+        $scope.APIError = true;
+        $scope.message = "Oh no, the Alerta API has returned status code " + response.status + "! Please check the submitted query."
+        console.log("Error with request to Alerta API")
+        console.log("Status code: " + response.status)
+        console.log("Status text: " + response.statusText)
+        $scope.alerts = [];
+      }
+      Alert.query($scope.query, success, error);
     };
     var refreshWithTimeout = function() {
       if ($scope.autoRefresh) {

--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -261,9 +261,6 @@ alertaControllers.controller('AlertListController', ['$scope', '$route', '$locat
       var error = function(response) {
         $scope.APIError = true;
         $scope.message = "Oh no, the Alerta API has returned status code " + response.status + "! Please check the submitted query."
-        console.log("Error with request to Alerta API")
-        console.log("Status code: " + response.status)
-        console.log("Status text: " + response.statusText)
         $scope.alerts = [];
       }
       Alert.query($scope.query, success, error);

--- a/app/partials/alert-list.html
+++ b/app/partials/alert-list.html
@@ -2,6 +2,11 @@
 
 <div class="container-fluid">
 
+  <div class="row" ng-show="showMongoQueryForm">
+    <div class="col-md-12 col-sm-12 col-xs-12">
+      <input class="form-control input" ng-model="mongoQuery" ng-change="update()" size="8" placeholder="Mongo query">
+    </div>
+  </div> <!-- row -->
   <div class="row">
     <div class="col-md-3 col-sm-3 col-xs-12">
         <select class="form-control input-sm" ng-model="option" ng-change="setService(option)"
@@ -71,7 +76,11 @@
           <center><img src="img/loading.gif"/></center>
       </div>
 
-      <div ng-show="alerts.length == 0">
+      <div ng-show="alerts.length == 0 && !APIError">
+          <center>{{ message }}</center>
+      </div>
+
+      <div class="alert alert-danger" role="alert" ng-show="alerts.length == 0 && APIError">
           <center>{{ message }}</center>
       </div>
 

--- a/app/partials/alert-list.html
+++ b/app/partials/alert-list.html
@@ -76,14 +76,9 @@
           <center><img src="img/loading.gif"/></center>
       </div>
 
-      <div ng-show="alerts.length == 0 && !APIError">
+      <div ng-class="{'alert alert-danger': APIError}" ng-show="alerts.length == 0">
           <center>{{ message }}</center>
       </div>
-
-      <div class="alert alert-danger" role="alert" ng-show="alerts.length == 0 && APIError">
-          <center>{{ message }}</center>
-      </div>
-
     </div>
   </div> <!-- row -->
 

--- a/web.js
+++ b/web.js
@@ -23,7 +23,8 @@ app.get('/config.js', function(request, response) {
         'client_id'   : '" + process.env.CLIENT_ID + "', \
         'github_url'  : '" + (process.env.GITHUB_URL || 'https://github.com') + "', \
         'gitlab_url'  : '" + process.env.GITLAB_URL + "', \
-        'tracking_id' : '" + process.env.TRACKING_ID + "' \
+        'tracking_id' : '" + process.env.TRACKING_ID + "', \
+        'backend_db'  : '" + process.env.BACKEND_DB + "', \
       });";
 
   response.send(config);


### PR DESCRIPTION
This PR adds a text box in which you can filter via a raw Mongo query:

<img width="1939" alt="image" src="https://user-images.githubusercontent.com/3106180/42695582-bf34a4ee-86ad-11e8-842e-0c86d1d5cb51.png">

If the query is invalid, the following box appears:

<img width="1941" alt="image" src="https://user-images.githubusercontent.com/3106180/42695602-d66e6190-86ad-11e8-9a81-10f8162007f3.png">

It only appears if "backend_db" == "mongodb" in the config as obviously this doesn't work if postgres is the backend db. It does not update the counts in the environment tabs, but this is a little broken anyway as the existing filtering doesn't update them either.
