### PR TITLE
GitLab OAuth only needs openid scope

### DIFF
--- a/app/js/auth.js
+++ b/app/js/auth.js
@@ -46,6 +46,8 @@ angular.module('alerta')
       url: config.endpoint+'/auth/gitlab',
       redirectUri: window.location.origin,
       clientId: config.client_id,
+      requiredUrlParams: ['scope'],
+      scope: 'openid',
       authorizationEndpoint: config.gitlab_url+'/oauth/authorize'
     });
     $authProvider.oauth2({


### PR DESCRIPTION
Following https://github.com/alerta/alerta/pull/638 GitLab OAuth only requires "openid" scope.