### PR TITLE
Log error to console if deprecated config.js found

### DIFF
--- a/app/js/bootstrap.js
+++ b/app/js/bootstrap.js
@@ -4,6 +4,26 @@ var alerta = alerta || {};
 
 
 angular.element(document).ready(function() {
+  var configJsCheck = function() {
+    $.ajax({
+        url: 'config.js',
+        type:'HEAD',
+        success: function() {
+          console.error(
+            'ERROR: Configuration in config.js file is no longer supported. ' +
+            'Use config.json file instead. See for more info: ' +
+            'https://docs.alerta.io/en/latest/webui.html'
+          );
+        },
+        error: function() {
+          console.log(
+            'INFO: Ignore 404 File not found errors for config.js files. ' +
+            'Checking for deprecated configuration in config.js file. [OK]'
+          );
+        }
+    });
+  };
+
   var bootstrap = function() {
     alerta.loadRoutes();
     alerta.loadAuth();
@@ -15,7 +35,9 @@ angular.element(document).ready(function() {
   }).always(function(localConfig) {
     $.getJSON(localConfig.endpoint + '/config').done(function(remoteConfig) {
       alerta.setConfig(remoteConfig);
-    }).then(function() {
+    })
+    .then(function() {
+      configJsCheck();
       bootstrap();
     });
   });


### PR DESCRIPTION
Log error to web console instead of in API server. see https://github.com/alerta/alerta/issues/676