### PR TITLE
Make alert list columns configurable

### DIFF
--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -190,21 +190,6 @@ angular.module('alerta')
 
       $scope.alerts = [];
       $scope.alertLimit = 20;
-      $scope.reverse = true;
-
-      $scope.sortByTime = config.sort_by || 'lastReceiveTime';
-      $scope.sortByTimeField = $scope.sortByTime.replace(/^\-/,'');
-
-      if ($scope.sortByTime.startsWith('-')) {
-        $scope.query = {
-          'sort-by': $scope.sortByTimeField,
-          'reverse': 1
-        }
-      } else {
-        $scope.query = {
-          'sort-by': $scope.sortByTimeField
-        }
-      };
 
       $scope.setService = function(s) {
         if (s) {
@@ -329,6 +314,31 @@ angular.module('alerta')
       };
 
       $scope.audio = config.audio;
+
+      $scope.columns = config.columns;
+
+      $scope.sortByTime = config.sort_by || 'lastReceiveTime';
+      $scope.sortByTimeField = $scope.sortByTime.replace(/^\-/,'');
+
+      if ($scope.sortByTime.startsWith('-')) {
+        $scope.query = {
+          'sort-by': $scope.sortByTimeField,
+          'reverse': 1
+        }
+      } else {
+        $scope.query = {
+          'sort-by': $scope.sortByTimeField
+        }
+      };
+
+      $scope.predicate = [$scope.reverseSeverityCode, $scope.sortByTime];
+      $scope.reverse = true;
+
+      $scope.toggleSort = function(col) {
+        $scope.predicate = col;
+        $scope.reverse = !$scope.reverse;
+      };
+
       $scope.$watch('alerts', function(current, old) {
         if (current.length > old.length && $scope.status.value.indexOf('open') > -1) {
           $scope.play = true;

--- a/app/partials/alert-list.html
+++ b/app/partials/alert-list.html
@@ -34,36 +34,52 @@
   <div class="row">
     <div class="col-md-12">
       <table class="table">
-        <tr ng-init="predicate = [reverseSeverityCode,sortByTime]">
-          <th class="hidden-xs"><a href="" ng-click="predicate = severityCode; reverse=!reverse">Severity&nbsp;<span ng-hide="predicate != severityCode"><span ng-show="!reverse">v</span><span ng-show="reverse">^</span></span></a></th>
-          <th class="hidden-xs"><a href="" ng-click="predicate = 'status'; reverse=!reverse">Status&nbsp;<span ng-hide="predicate != 'status'"><span ng-show="!reverse">^</span><span ng-show="reverse">v</span></span></a></th>
-          <th class="hidden-lg"><a href="" ng-click="predicate = sortByTime; reverse=!reverse">Time&nbsp;<span ng-hide="predicate != sortByTime"><span ng-show="!reverse">^</span><span ng-show="reverse">v</span></span></a></th>
-          <th class="visible-lg"><a href="" ng-click="predicate = sortByTime; reverse=!reverse">{{ sortByTimeField | splitcaps }}&nbsp;<span ng-hide="predicate != sortByTime"><span ng-show="!reverse">^</span><span ng-show="reverse">v</span></span></a></th>
-          <th class="visible-lg"><a href="" ng-click="predicate = 'duplicateCount'; reverse=!reverse">Dupl.&nbsp;<span ng-hide="predicate != 'duplicateCount'"><span ng-show="!reverse">^</span><span ng-show="reverse">v</span></span></a></th>
-          <th class="hidden-xs" ng-show="isCustomerViews();"><a href="" ng-click="predicate = 'customer'; reverse=!reverse">Customer&nbsp;<span ng-hide="predicate != 'customer'"><span ng-show="!reverse">^</span><span ng-show="reverse">v</span></span></a></th>
-          <th class="hidden-xs"><a href="" ng-click="predicate = 'environment'; reverse=!reverse">Environment&nbsp;<span ng-hide="predicate != 'environment'"><span ng-show="!reverse">^</span><span ng-show="reverse">v</span></span></a></th>
-          <th class="hidden-xs"><a href="" ng-click="predicate = 'service'; reverse=!reverse">Service&nbsp;<span ng-hide="predicate != 'service'"><span ng-show="!reverse">^</span><span ng-show="reverse">v</span></span></a></th>
-          <th><a href="" ng-click="predicate = 'resource'; reverse=!reverse">Resource&nbsp;<span ng-hide="predicate != 'resource'"><span ng-show="!reverse">^</span><span ng-show="reverse">v</span></span></a></th>
-          <th><a href="" ng-click="predicate = 'event'; reverse=!reverse">Event&nbsp;<span ng-hide="predicate != 'event'"><span ng-show="!reverse">^</span><span ng-show="reverse">v</span></span></a></th>
-          <th class="hidden-xs"><a href="" ng-click="predicate = 'value'; reverse=!reverse">Value&nbsp;<span ng-hide="predicate != 'value'"><span ng-show="!reverse">^</span><span ng-show="reverse">v</span></span></a></th>
-          <th class="hidden-xs"><a href="" ng-click="predicate = 'text'; reverse=!reverse">Text&nbsp;<span ng-hide="predicate != 'text'"><span ng-show="!reverse">^</span><span ng-show="reverse">v</span></span></a></th>
+        <tr>
+          <th ng-repeat="col in columns">
+            <a href="" ng-click="toggleSort(col)">
+              <span ng-show="col == 'duplicateCount'">Dupl. </span>
+              <span ng-show="col == 'customer' && isCustomerViews()">Customer </span>
+              <span ng-show="col != 'duplicateCount' && col != 'customer'">{{ col | splitcaps }} </span>
+              <span ng-hide="predicate != col"><span ng-show="!reverse">v</span><span ng-show="reverse">^</span></span>
+            </a>
+          </th>
         </tr>
 
         <tr ng-repeat="alert in alerts | filter:search | orderBy:predicate:reverse | limitTo:alertLimit"
             ng-style="{ 'color':  colors.severity[alert.severity] == 'black' ? 'white' : colors.text, 'background-color': (bulkAlerts.indexOf(alert.id) > -1) ? colors.highlight : colors.severity[alert.severity] || 'silver' }"
             ng-click="click($event,alert);">
-          <td class="hidden-xs no-wrap"><i class="glyphicon glyphicon-{{ alert.trendIndication | arrow }}"></i>&nbsp;<span class="label label-{{ alert.severity }}">{{ alert.severity | capitalize }}</span></td>
-          <td class="hidden-xs"><span class="label label-{{ alert.status }}">{{ alert.status | capitalize }}</span></td>
-          <td class="hidden-lg">{{ alert[sortByTimeField] | date:shortTime }}</td>
-          <td class="visible-lg">{{ alert[sortByTimeField] | date:mediumDate }}</td>
-          <td class="visible-lg">{{ alert.duplicateCount }}</td>
-          <td class="hidden-xs" ng-show="isCustomerViews();">{{ alert.customer }}</td>
-          <td class="hidden-xs">{{ alert.environment }}</td>
-          <td class="hidden-xs">{{ alert.service.join(', ') }}</td>
-          <td>{{ alert.resource }}</td>
-          <td>{{ alert.event }}</td>
-          <td class="hidden-xs">{{ alert.value }}</td>
-          <td class="hidden-xs"><span ng-bind-html="alert.text"></span></td>
+          <td ng-repeat="col in columns">
+            <span ng-if="col == 'id'">{{ alert.id | shortid }}</span>
+            <span ng-if="col == 'resource'">{{ alert.resource }}</span>
+            <span ng-if="col == 'event'">{{ alert.event }}</span>
+            <span ng-if="col == 'environment'">{{ alert.environment }}</span>
+            <span ng-if="col == 'severity'">
+              <span style="white-space: nowrap"><i class="glyphicon glyphicon-{{ alert.trendIndication | arrow }}"></i> <span class="label label-{{ alert.severity }}">{{ alert.severity | capitalize }}</span></span>
+            </span>
+            <span ng-if="col == 'correlate'">{{ alert.correlate.join(', ') }}</span>
+            <span ng-if="col == 'status'"><span class="label label-{{ alert.status }}">{{ alert.status | capitalize }}</span></span>
+            <span ng-if="col == 'service'">{{ alert.service.join(', ') }}</span>
+            <span ng-if="col == 'group'">{{ alert.group }}</span>
+            <span ng-if="col == 'value'">{{ alert.value }}</span>
+            <span ng-if="col == 'text'"><span ng-bind-html="alert.text | linky:'_blank'"></span></span>
+            <span ng-if="col == 'tags'"><span ng-repeat="tag in alert.tags"><span class="label label-primary">{{ tag }}</span> </span></span>
+            <span ng-if="alert.attributes.hasOwnProperty(col)"><span ng-bind-html="alert.attributes[col]"></span></span>
+            <span ng-if="col == 'origin'">{{ alert.origin }}</span>
+            <span ng-if="col == 'type'"><span class="label">{{ alert.type | splitcaps }}</span></span>
+            <span ng-if="col == 'createTime'">{{ alert.createTime | date:mediumDate }}</span>
+            <span ng-if="col == 'timeout'">{{ alert.timeout }}</span>
+            <!-- rawData not supported -->
+            <span ng-if="col == 'customer' && isCustomerViews()">{{ alert.customer }}</span>
+
+            <span ng-if="col == 'duplicateCount'">{{ alert.duplicateCount }}</span>
+            <span ng-if="col == 'repeat'"><span class="label">{{ alert.repeat | capitalize }}</span></span>
+            <span ng-if="col == 'previousSeverity'"><span class="label label-{{ alert.previousSeverity }}">{{ alert.previousSeverity | capitalize }}</span></span>
+            <span ng-if="col == 'trendIndication'"><i class="glyphicon glyphicon-{{ alert.trendIndication | arrow }}"></i></span>
+            <span ng-if="col == 'receiveTime'">{{ alert.receiveTime | date:mediumDate }}</span>
+            <span ng-if="col == 'lastReceiveId'">{{ alert.lastReceiveId | shortid }}</span>
+            <span ng-if="col == 'lastReceiveTime'">{{ alert.lastReceiveTime | date:mediumDate }}</span>
+            <!-- history not supported -->
+          </td>
         </tr>
       </table>
 


### PR DESCRIPTION

<img width="1257" alt="screenshot 2018-10-12 at 11 12 14" src="https://user-images.githubusercontent.com/615057/46860041-c8977300-ce0f-11e8-8238-6e9d954ad393.png">

Setting in server config file `COLUMNS`. See https://github.com/alerta/alerta/pull/707

**Default**
```
COLUMNS = ['severity', 'status', 'lastReceiveTime', 'duplicateCount',
           'customer', 'environment', 'service', 'resource', 'event', 'value', 'text']
```

**Example**
```
COLUMNS = [
    'region',  # note: region is an alert attribute
    'customer',
    'duplicateCount',
    'createTime',
    'severity',
    'status',
    'tags',
    'event',
    'correlate',
    'id',
    'group',
    'origin',
    'type',
    'timeout',
    'trendIndication',
    'previousSeverity',
    'repeat',
    'service',
    'lastReceiveId'
]
SORT_LIST_BY = '-createTime'  # attribute to be sorted on is independent of what is displayed
```

**Note:** This breaks the responsive view for alert list. ie. it won't some hide/show columns as the viewport width shrinks/grows. Not sure what the solution to this is, yet.