### PR TITLE
Add user-configurable action buttons

### DIFF
--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -571,6 +571,19 @@ angular.module('alerta')
         });
       };
 
+      $scope.actions = config.actions;
+
+      $scope.actionAlert = function(id, action) {
+        Alert.action({
+          id: id
+        }, {
+          action: action,
+          text: action + byUser
+        }, function(data) {
+          $route.reload();
+        });
+      };
+
       $scope.tagged = function(tags, tagged) {
         angular.forEach(tags, function(tag) {
           if (tag == tagged) {

--- a/app/partials/alert-details.html
+++ b/app/partials/alert-details.html
@@ -31,6 +31,11 @@
   <button ng-disabled="!hasPermission('write:alerts')" type="button" class="btn btn-primary"
           ng-click="ackAlert(alert.id)"
           ng-disabled="alert.status == 'ack'"><i class="glyphicon glyphicon-ok-circle"></i> Ack</button>
+
+  <span ng-repeat="action in actions">
+    <button ng-click="actionAlert(alert.id, action)" type="button" class="btn btn-default"><i class="glyphicon glyphicon-wrench"></i> {{ action | splitcaps }}</button>
+  </span>
+
   <button ng-disabled="!hasPermission('write:alerts')" type="button" class="btn btn-warning"
           ng-click="closeAlert(alert.id)"
           ng-disabled="alert.status == 'closed'"><i class="glyphicon glyphicon-remove-circle"></i> Close</button>


### PR DESCRIPTION
Reads server config setting `ACTIONS = ['ticket'`]` and creates a button in the details page that submits the action.

See https://github.com/alerta/alerta/pull/554 and https://github.com/alerta/alerta/pull/708