### PR TITLE
Use scopes when creating new API keys

### DIFF
--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -1228,6 +1228,7 @@ angular.module('alerta')
 
       $scope.perms = [];
       $scope.perm = '';
+      $scope.scope = '';
       $scope.match = '';
 
       $scope.createPerm = function(scope, match) {
@@ -1292,31 +1293,14 @@ angular.module('alerta')
     function($scope, $route, $timeout, $auth, config, Keys) {
 
       $scope.keys = [];
-      $scope.type = {
-        name: 'read-only',
-        scopes: ['read']
-      };
+      $scope.scope = ''
       $scope.text = '';
 
-      $scope.types = [{
-          name: 'admin',
-          scopes: ['read', 'write', 'admin']
-        },
-        {
-          name: 'read-write',
-          scopes: ['read', 'write']
-        },
-        {
-          name: 'read-only',
-          scopes: ['read']
-        }
-      ];
-
-      $scope.createKey = function(type, customer, text) {
+      $scope.createKey = function(scope, customer, text) {
         var login = $auth.getPayload().preferred_username || $auth.getPayload().login;
         Keys.save({}, {
           user: login,
-          scopes: type.scopes,
+          scopes: scope.split(' '),
           customer: customer,
           text: text
         }, function(data) {

--- a/app/partials/keys.html
+++ b/app/partials/keys.html
@@ -33,21 +33,18 @@
       </table>
 
       <div>
-      <form name="form" class="form-inline css-form" novalidate>
-        <div class="row">
-        <div class="form-group col-md-5 col-sm-4 col-xs-4">
-              <input type="text" class="form-control" id="text" placeholder="Application requiring API Key" ng-model="text" name="text" required />
+        <div class="form-group row">
+        <div class="col-xs-2">
+              <input type="text" class="form-control" id="text" placeholder="Application" ng-model="text" name="text" required />
         </div>
-        <div class="form-group col-md-2 col-sm-2 col-xs-2">
+        <div class="col-xs-4">
+          <input class="form-control" id="input-scopes" placeholder="Scopes eg. admin write read:alerts admin:keys" ng-model="scope" name="scope" required />
+        </div>
+        <div class="col-xs-2">
               <input type="text" class="form-control" id="customer" placeholder="Customer (optional)" ng-model="customer" name="customer" />
         </div>
-        <div class="col-md-1 col-sm-1 col-xs-1">
-          <select class="form-control input-md" ng-options="key as key.name for key in types track by key.name" ng-model="type"></select>
-          </select>
+        <button ng-disabled="!hasPermission('write:keys')" type="button" class="btn btn-primary" ng-click="createKey(scope, customer, text)">Create new API Key</button>
         </div>
-        <button ng-disabled="!hasPermission('write:keys')" type="button" class="btn btn-primary" ng-click="createKey(type, customer, text)">Create new API Key</button>
-        </div>
-      </form>
       </div>
 
     </div>


### PR DESCRIPTION
Replace drop-down with only three scope aliases "admin", "read-write" and "read-only" ...

<img width="607" alt="screenshot 2018-10-15 at 00 04 00" src="https://user-images.githubusercontent.com/615057/46922747-fb0ebf00-d00d-11e8-8785-6fbebe393fd8.png">

... with ability for fine-grained control over scopes ...

<img width="959" alt="screenshot 2018-10-15 at 00 04 49" src="https://user-images.githubusercontent.com/615057/46922746-f4804780-d00d-11e8-9d2b-3a1c16f33006.png">

| old | new | 
| --- | --- |
| admin | admin | 
| read-write | read write | 
| read-only | read | 
