### PR TITLE
Add support for LDAP logins with Alerta API v7

### DIFF
--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -80,11 +80,11 @@ angular.module('alerta')
       };
 
       $scope.isBasicAuth = function() {
-        return config.provider == 'basic';
+        return config.provider == 'basic' || config.provider == 'ldap';
       };
 
       $scope.authenticate = function() {
-        if (config.provider == 'basic') {
+        if ($scope.isBasicAuth) {
           $location.path('/login');
         } else if (config.provider == 'saml2') {
           let auth_win;

--- a/app/partials/login.html
+++ b/app/partials/login.html
@@ -6,7 +6,7 @@
     </div>
   </div>
 
-  <div class="container" ng-show="provider == 'basic'">
+  <div class="container" ng-show="provider == 'basic' || provider == 'ldap'">
     <div class="col-sm-6 col-md-4 col-md-offset-4">
       <form>
         <div class="form-group">


### PR DESCRIPTION
This allows the v6 web UI (AngularJS) to be used with v7 API when LDAP auth is used.

Note: The `AUTH_PROVIDER` setting for LDAP in v6 API was `basic` but this changed to `ldap` in v7 API so this is required for "forward compatibility".

Fixes #197 